### PR TITLE
Annotateable to annotatable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,11 @@
 /test/
 
 # top level source
-glade-annotateable.js
-glade-annotateable.js.map
-glade-annotateable.d.ts
-glade-annotateable.d.ts.map
-glade-annotateable.bundled.js
+glade-annotatable.js
+glade-annotatable.js.map
+glade-annotatable.d.ts
+glade-annotatable.d.ts.map
+glade-annotatable.bundled.js
 
 /app/node_modules/
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# glade-element [![Published on npm](https://img.shields.io/npm/v/@glade-software/glade-annotateable.svg)](https://www.npmjs.com/package/@glade-software/glade-annotateable)
+# glade-annotatable [![Published on npm](https://img.shields.io/npm/v/@glade-software/glade-annotatable.svg)](https://www.npmjs.com/package/@glade-software/glade-annotatable)
 
 ### Glade's vision for the internet is that every webpage can be annotated by any user.
 

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -2,8 +2,8 @@
   "version": "experimental",
   "tags": [
     {
-      "name": "glade-annotateable",
-      "path": "./src/glade-annotateable.ts",
+      "name": "glade-annotatable",
+      "path": "./src/glade-annotatable.ts",
       "attributes": [
         {
           "name": "verbose",

--- a/demos/blog.html
+++ b/demos/blog.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>&lt;glade-annotateable> blog Demo</title>
+    <title>&lt;glade-annotatable> blog Demo</title>
     <script
       type="module"
-      src="https://unpkg.com/@glade-software/glade-annotateable"
+      src="https://unpkg.com/@glade-software/glade-annotatable"
     ></script>
     <style>
       p {
@@ -13,7 +13,7 @@
         font-family: Arial, Helvetica, sans-serif;
       }
 
-      glade-annotateable > * {
+      glade-annotatable > * {
         cursor: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAEqADAAQAAAABAAAAEgAAAACaqbJVAAAAQ0lEQVQ4EWNkwA/+o0kzovHhXCY4i0LGqEGEA5BqYQSKTvQoJmw9FhVUc9HgMwhnkocGA3r44VQ/+Lw26iIsSRlNCABZuwMhw3OLPQAAAABJRU5ErkJggg==),
           auto;
       }
@@ -27,12 +27,12 @@
 
   <body>
     <a
-      href="https://github.com/glade-software/glade-element/tree/master/demos/blog.html"
+      href="https://github.com/glade-software/glade-annotatable/tree/master/demos/blog.html"
     >
       <pre>source code</pre>
     </a>
     <p>October 10 2020</p>
-    <glade-annotateable>
+    <glade-annotatable>
       <p>Today is my first Saturday working on Glade in a long time.</p>
       <p>
         I hope I do this more often, working on this project always feels good.
@@ -44,13 +44,13 @@
       <p>
         You can check out the source code for this post at the link above, if
         you are looking for the source for the annotation platform thats
-        <a href="https://github.com/glade-software/glade-element">here</a>.
+        <a href="https://github.com/glade-software/glade-annotatable">here</a>.
       </p>
       <p>If you find yourself here please leave an annotation!</p>
       <p>
         I'm going to move on to writing some docs now, thanks for checking this
         out, add an issue to the repo if you have any ideas for improvements!
       </p>
-    </glade-annotateable>
+    </glade-annotatable>
   </body>
 </html>

--- a/demos/docs-example.html
+++ b/demos/docs-example.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>&lt;glade-annotateable> docs example Demo</title>
+    <title>&lt;glade-annotatable> docs example Demo</title>
     <script
       type="module"
-      src="https://unpkg.com/@glade-software/glade-annotateable"
+      src="https://unpkg.com/@glade-software/glade-annotatable"
     ></script>
     <style>
       p {
@@ -13,7 +13,7 @@
         font-family: Arial, Helvetica, sans-serif;
       }
 
-      glade-annotateable > * {
+      glade-annotatable > * {
         cursor: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAEqADAAQAAAABAAAAEgAAAACaqbJVAAAAQ0lEQVQ4EWNkwA/+o0kzovHhXCY4i0LGqEGEA5BqYQSKTvQoJmw9FhVUc9HgMwhnkocGA3r44VQ/+Lw26iIsSRlNCABZuwMhw3OLPQAAAABJRU5ErkJggg==),
           auto;
       }
@@ -27,18 +27,18 @@
 
   <body>
     <a
-      href="https://github.com/glade-software/glade-element/tree/master/demos/docs-example.html"
+      href="https://github.com/glade-software/glade-annotatable/tree/master/demos/docs-example.html"
     >
       <pre>source code</pre>
     </a>
     <p>Docs Example</p>
-    <glade-annotateable>
+    <glade-annotatable>
       <p>This is a simple example for demonstration purposes.</p>
       <p>
         If you came here from the
         <a href="https://docs.glade.app/docs/getting-started">documentation</a>
         please add an annotation here!
       </p>
-    </glade-annotateable>
+    </glade-annotatable>
   </body>
 </html>

--- a/demos/index.html
+++ b/demos/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>&lt;glade-annotateable> Demos</title>
+    <title>&lt;glade-annotatable> Demos</title>
     <style>
       p,
       ul,
@@ -15,7 +15,7 @@
 
   <body>
     <a
-      href="https://github.com/glade-software/glade-element/tree/master/demos/index.html"
+      href="https://github.com/glade-software/glade-annotatable/tree/master/demos/index.html"
     >
       <pre>source code</pre>
     </a>

--- a/dev/index.html
+++ b/dev/index.html
@@ -3,8 +3,8 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>&lt;glade-annotateable> Demo</title>
-    <script type="module" src="../glade-annotateable.js"></script>
+    <title>&lt;glade-annotatable> Demo</title>
+    <script type="module" src="../glade-annotatable.js"></script>
 
     <style>
       p {
@@ -12,11 +12,11 @@
         font-family: Arial, Helvetica, sans-serif;
       }
 
-      glade-annotateable > :not(.glade-has-annotations) {
+      glade-annotatable > :not(.glade-has-annotations) {
         cursor: cell;
       }
 
-      glade-annotateable > .glade-has-annotations {
+      glade-annotatable > .glade-has-annotations {
         background-color: skyblue;
         cursor: context-menu;
       }
@@ -26,8 +26,8 @@
   <body>
     <p>Restless Lyrics</p>
 
-    <glade-annotateable verbose>
+    <glade-annotatable verbose>
       <p>This is the new dev document for Glade.</p>
-    </glade-annotateable>
+    </glade-annotatable>
   </body>
 </html>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# glade-element [![Published on npm](https://img.shields.io/npm/v/@glade-software/glade-annotateable.svg)](https://www.npmjs.com/package/@glade-software/glade-annotateable)
+# glade-annotatable [![Published on npm](https://img.shields.io/npm/v/@glade-software/glade-annotatable.svg)](https://www.npmjs.com/package/@glade-software/glade-annotatable)
 
 ### Glade's vision for the internet is that every webpage can be annotated by any user.
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -9,17 +9,17 @@ To get started you just need to include our javascript library on your page like
 ```html
 <script
   type="module"
-  src="https://unpkg.com/@glade-software/glade-annotateable"
+  src="https://unpkg.com/@glade-software/glade-annotatable"
 ></script>
 ```
 
 Next, wrap your content with our newly declared custom element
 
 ```html
-<glade-annotateable>
+<glade-annotatable>
   <p>This content can be whatever you want!</p>
   <p>Users will be able to click on it, sign in, and add annotations!</p>
-</glade-annotateable>
+</glade-annotatable>
 ```
 
 Now, users will be able to click on any DOM node within that body of content to add an annotation 🎉

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -6,11 +6,11 @@ sidebar_label: Glossary
 
 ### Document
 
-A **document** in Glade is _not_ synonymous with an HTML document. A Glade **document** instead refers to an entire DOM structure that is inside a glade-annotateable tag.
+A **document** in Glade is _not_ synonymous with an HTML document. A Glade **document** instead refers to an entire DOM structure that is inside a glade-annotatable tag.
 
 ### Referent
 
-A **referent** is a given portion of DOM that an annotation refers to. Currently Glade referents are just DOM nodes that are inside a glade-annotateable tag, and are not nested any deeper than that.
+A **referent** is a given portion of DOM that an annotation refers to. Currently Glade referents are just DOM nodes that are inside a glade-annotatable tag, and are not nested any deeper than that.
 
 ### Annotation
 

--- a/docs/docs/implementation.md
+++ b/docs/docs/implementation.md
@@ -13,10 +13,10 @@ Wrapping content with the Glade custom element augments that content and makes i
 That's done like this:
 
 ```html
-<glade-annotateable>
+<glade-annotatable>
   <p>Lorem Ipsum</p>
   <p>I don't know latin</p>
-</glade-annotateable>
+</glade-annotatable>
 ```
 
 ## User Experience

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -1,11 +1,11 @@
 module.exports = {
-  title: '<glade-annotateable>',
+  title: '<glade-annotatable>',
   tagline: 'make any webpage annotateable',
   url: 'https://docs.glade.app',
   baseUrl: '/',
   favicon: 'img/favicon.ico',
   organizationName: 'glade-software', // Usually your GitHub org/user name.
-  projectName: 'glade-element', // Usually your repo name.
+  projectName: 'glade-annotatable', // Usually your repo name.
   themeConfig: {
     navbar: {
       title: 'Glade',
@@ -22,7 +22,7 @@ module.exports = {
         },
         {href: 'https://demos.glade.app', label: 'Demos', position: 'left'},
         {
-          href: 'https://github.com/glade-software/glade-element',
+          href: 'https://github.com/glade-software/glade-annotatable',
           label: 'GitHub',
           position: 'right',
         },
@@ -63,7 +63,7 @@ module.exports = {
             },
             {
               label: 'GitHub',
-              href: 'https://github.com/glade-software/glade-element',
+              href: 'https://github.com/glade-software/glade-annotatable',
             },
           ],
         },
@@ -81,13 +81,13 @@ module.exports = {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           editUrl:
-            'https://github.com/glade-software/glade-element/edit/master/docs/',
+            'https://github.com/glade-software/glade-annotatable/edit/master/docs/',
         },
         demos: {
           showReadingTime: true,
           // Please change this to your repo.
           editUrl:
-            'https://github.com/glade-software/glade-element/edit/master/demos/',
+            'https://github.com/glade-software/glade-annotatable/edit/master/demos/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -12,15 +12,15 @@ function Home() {
   const {siteConfig = {}} = context;
   return (
     <>
-      <Layout title={`Glade`} description="Docs  <glade-annotateable>">
+      <Layout title={`Glade`} description="Docs  <glade-annotatable>">
         <Head>
           <script
             type="module"
-            src="https://unpkg.com/@glade-software/glade-annotateable"
+            src="https://unpkg.com/@glade-software/glade-annotatable"
           ></script>
           <style>
             {`
-            glade-annotateable > * {
+            glade-annotatable > * {
               cursor: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAEqADAAQAAAABAAAAEgAAAACaqbJVAAAAQ0lEQVQ4EWNkwA/+o0kzovHhXCY4i0LGqEGEA5BqYQSKTvQoJmw9FhVUc9HgMwhnkocGA3r44VQ/+Lw26iIsSRlNCABZuwMhw3OLPQAAAABJRU5ErkJggg==),
                 auto;
             }
@@ -53,12 +53,12 @@ function Home() {
           <section className={styles.features}>
             <div className="container">
               <div className="row">
-                <glade-annotateable verbose>
+                <glade-annotatable verbose>
                   <p>
                     This homepage content is annotateable using Glade's open
                     annotation platform!
                   </p>
-                </glade-annotateable>
+                </glade-annotatable>
               </div>
             </div>
           </section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@glade-software/glade-annotateable",
+  "name": "@glade-software/glade-annotatable",
   "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@glade-software/glade-annotatable",
-  "version": "1.0.7",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "@glade-software/glade-annotateable",
+  "name": "@glade-software/glade-annotatable",
   "version": "1.0.7",
   "description": "a component that makes DOM annotateable",
-  "main": "glade-annotateable.bundled.js",
-  "module": "glade-annotateable.js",
-  "unpkg": "glade-annotateable.bundled.js",
+  "main": "glade-annotatable.bundled.js",
+  "module": "glade-annotatable.js",
+  "unpkg": "glade-annotatable.bundled.js",
   "type": "module",
   "files": [
-    "glade-annotateable.bundled.js"
+    "glade-annotatable.bundled.js"
   ],
   "scripts": {
     "build": "tsc && rollup -c",
     "build:watch": "tsc --watch && rollup -c -w",
-    "clean": "rimraf glade-annotateable.{d.ts,d.ts.map,js,bundled.js,js.map} test/glade-annotateable.{d.ts,d.ts.map,js,js.map} test/glade-annotateable_test.{d.ts,d.ts.map,js,js.map}",
+    "clean": "rimraf glade-annotatable.{d.ts,d.ts.map,js,bundled.js,js.map} test/glade-annotatable.{d.ts,d.ts.map,js,js.map} test/glade-annotatable_test.{d.ts,d.ts.map,js,js.map}",
     "lint": "npm run lint:lit-analyzer && npm run lint:eslint",
     "lint:eslint": "eslint 'src/**/*.ts'",
     "lint:lit-analyzer": "lit-analyzer",
@@ -24,7 +24,7 @@
     "test:watch": "karma start karma.conf.cjs --auto-watch=true --single-run=false",
     "test:update-snapshots": "karma start karma.conf.cjs --update-snapshots",
     "test:prune-snapshots": "karma start karma.conf.cjs --prune-snapshots",
-    "checksize": "rollup -c ; cat glade-annotateable.bundled.js | gzip -9 | wc -c ; rm glade-annotateable.bundled.js"
+    "checksize": "rollup -c ; cat glade-annotatable.bundled.js | gzip -9 | wc -c ; rm glade-annotatable.bundled.js"
   },
   "keywords": [
     "web-components",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glade-software/glade-annotatable",
-  "version": "1.0.7",
+  "version": "1.0.0",
   "description": "a component that makes DOM annotateable",
   "main": "glade-annotatable.bundled.js",
   "module": "glade-annotatable.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,9 +17,9 @@ import resolve from 'rollup-plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 
 export default {
-  input: 'glade-annotateable.js',
+  input: 'glade-annotatable.js',
   output: {
-    file: 'glade-annotateable.bundled.js',
+    file: 'glade-annotatable.bundled.js',
     format: 'esm',
   },
   onwarn(warning) {

--- a/src/glade-element.ts
+++ b/src/glade-element.ts
@@ -14,7 +14,7 @@ enum DialogRole {
 }
 
 @customElement('glade-annotatable')
-export class GladeAnnotatable extends LitElement {
+export class GladeElement extends LitElement {
   /**
    * The content nodes inside the tag
    */
@@ -479,6 +479,6 @@ export class GladeAnnotatable extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'glade-annotatable': GladeAnnotatable;
+    'glade-annotatable': GladeElement;
   }
 }

--- a/src/test/glade-element_test.ts
+++ b/src/test/glade-element_test.ts
@@ -1,10 +1,10 @@
-import {GladeAnnotatable} from '../glade-annotatable.js';
+import {GladeElement} from '../glade-annotatable.js';
 
 const assert = chai.assert;
 
 suite('glade-annotatable', () => {
   test('is defined', () => {
     const el = document.createElement('glade-annotatable');
-    assert.instanceOf(el, GladeAnnotatable);
+    assert.instanceOf(el, GladeElement);
   });
 });


### PR DESCRIPTION
So, glade-annotateable is spelt incorrectly, yikes. I might read the new name as annotattable forever, but that is the way it must be.